### PR TITLE
Fix addwords form

### DIFF
--- a/FastBridgeApp/templates/import-words.html
+++ b/FastBridgeApp/templates/import-words.html
@@ -5,7 +5,7 @@
 <body>
   <section class="container text-center" style = "height: auto; padding-top: 150px; background-position: bottom; background-size: cover;">
 
-<form class="form" action="/account/addwords/handler" method="post" enctype= "multipart/form-data">
+<form class="form" action="/account/addwords/handler/" method="post" enctype= "multipart/form-data">
   <div class="form-group"
 <label for="language">
   What language are we adding to? (please capitalize) </label>


### PR DESCRIPTION
The problem was simply the lack of trailing slash.

Without this, the server would try to redirect to the slash, which would sometimes result in a race condition.

The server has been reverted back to using Gunicorn etc. It was just the slash all along.