### PR TITLE
Replace lemmatizer with CLTK+Stanza hybrid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ COPY . /app
 #install all the requirements
 RUN pip install --upgrade pip
 RUN pip install -r /app/requirements.txt
+RUN python -c "\
+from cltk.data.fetch import FetchCorpus; \
+FetchCorpus('lat').import_corpus('lat_models_cltk'); \
+FetchCorpus('grc').import_corpus('grc_models_cltk')"
 
 #change the working container directory to FastBridgeApp, so that the run command
 #can find the app in main.py

--- a/FastBridgeApp/routers/ToolsApp/lemmatize.py
+++ b/FastBridgeApp/routers/ToolsApp/lemmatize.py
@@ -1,4 +1,4 @@
-"""This router replaces the old Lemmatizer. Will take in a text, as either html text input or as a file. 
+"""This router replaces the old Lemmatizer. Will take in a text, as either html text input or as a file.
 It will return a lemmatized sheet that will be ready to be sent to the importer once a human has resolved/deleted all the titles that resolved to NONE
 """
 
@@ -19,6 +19,9 @@ logging.getLogger("stanza").setLevel(logging.WARNING)
 logging.getLogger("stanza").setLevel(logging.ERROR)
 logging.getLogger("stanza.pipeline").setLevel(logging.ERROR)
 
+from cltk.lemmatize.lat import LatinBackoffLemmatizer
+from cltk.lemmatize.grc import GreekBackoffLemmatizer
+
 router = APIRouter()
 router_path = Path.cwd()
 templates = Jinja2Templates(directory="templates")
@@ -28,26 +31,109 @@ stanza_pipelines = {
     "greek": None
 }
 
+cltk_lemmatizers = {
+    "latin": None,
+    "greek": None,
+}
+
+# Invariable Latin words — hardcoded ground truth
+LATIN_INVARIABLES = {
+    "in": "in", "et": "et", "ab": "ab", "ad": "ad", "cum": "cum",
+    "de": "de", "ex": "ex", "per": "per", "pro": "pro", "sub": "sub",
+    "sed": "sed", "non": "non", "at": "at", "ac": "ac", "aut": "aut",
+    "vel": "vel", "nec": "nec", "neque": "neque", "nam": "nam",
+    "enim": "enim", "igitur": "igitur", "ergo": "ergo", "tamen": "tamen",
+    "autem": "autem", "itaque": "itaque", "ante": "ante", "post": "post",
+    "inter": "inter", "super": "super", "contra": "contra", "sine": "sine",
+    "ob": "ob", "propter": "propter", "circa": "circa", "trans": "trans",
+    "que": "que", "ve": "ve", "ne": "ne",
+    "est": "sum", "sunt": "sum", "esse": "sum", "erat": "sum",
+    "erant": "sum", "erit": "sum", "erunt": "sum", "fuit": "sum",
+    "qui": "qui", "quae": "qui", "quod": "qui", "quem": "qui",
+    "quam": "qui", "quo": "qui", "qua": "qui", "quos": "qui",
+    "quas": "qui", "quibus": "qui", "cuius": "qui",
+    "se": "se", "sibi": "se", "sui": "se",
+}
+
+# Invariable Greek words — hardcoded ground truth
+GREEK_INVARIABLES = {
+    "καί": "καί", "καὶ": "καί",
+    "ὁ": "ὁ", "ἡ": "ὁ", "τό": "ὁ", "τόν": "ὁ", "τήν": "ὁ",
+    "τοῦ": "ὁ", "τῆς": "ὁ", "τῷ": "ὁ", "τῇ": "ὁ",
+    "τούς": "ὁ", "τάς": "ὁ", "τῶν": "ὁ", "τοῖς": "ὁ", "ταῖς": "ὁ",
+    "τὸν": "ὁ", "τὴν": "ὁ", "τὸ": "ὁ",
+    "ἐν": "ἐν", "εἰς": "εἰς", "ἐκ": "ἐκ", "ἐξ": "ἐκ",
+    "ἀπό": "ἀπό", "ἀπὸ": "ἀπό",
+    "πρός": "πρός", "πρὸς": "πρός",
+    "διά": "διά", "διὰ": "διά",
+    "μετά": "μετά", "μετὰ": "μετά",
+    "κατά": "κατά", "κατὰ": "κατά",
+    "παρά": "παρά", "παρὰ": "παρά",
+    "περί": "περί", "περὶ": "περί",
+    "ὑπό": "ὑπό", "ὑπὸ": "ὑπό",
+    "ἐπί": "ἐπί", "ἐπὶ": "ἐπί",
+    "δέ": "δέ", "δὲ": "δέ",
+    "μέν": "μέν", "μὲν": "μέν",
+    "οὐ": "οὐ", "οὐκ": "οὐ", "οὐχ": "οὐ",
+    "μή": "μή", "μὴ": "μή",
+    "γάρ": "γάρ", "γὰρ": "γάρ",
+    "ἀλλά": "ἀλλά", "ἀλλὰ": "ἀλλά",
+    "ὅτι": "ὅτι",
+    "εἰ": "εἰ",
+    "ὡς": "ὡς",
+    "ἄρα": "ἄρα",
+    "οὖν": "οὖν",
+    "αὐτός": "αὐτός", "αὐτοῦ": "αὐτός", "αὐτῷ": "αὐτός",
+    "αὐτόν": "αὐτός", "αὐτήν": "αὐτός", "αὐτό": "αὐτός",
+    "αὐτὸς": "αὐτός", "αὐτὸν": "αὐτός",
+}
+
+# Inflected endings that mean CLTK returned the word unchanged
+INFLECTED_ENDINGS = (
+    "bant", "bat", "batur", "bantur",
+    "erunt", "isse", "isset",
+    "abant", "abatur",
+    "entur", "antur", "itur", "untur",
+    "amque", "asque", "osque", "isque",
+    "esque", "oque", "aque",
+)
+
+
+def clean_cltk_lemma(lemma: str) -> str:
+    return lemma.rstrip("0123456789")
+
+
+def cltk_lemma_is_inflected(lemma: str, original_word: str) -> bool:
+    if lemma != original_word:
+        return False
+    return any(original_word.endswith(ending) for ending in INFLECTED_ENDINGS)
+
+
 def get_pipeline(language: str):
     global stanza_pipelines
-
     lang_code = {"latin": "la", "greek": "grc"}.get(language.lower())
     if not lang_code:
         raise ValueError(f"Unsupported language: {language}")
-
     if stanza_pipelines[language] is None:
         try:
             stanza.download(lang_code, verbose=False)
         except Exception as e:
             print(f"Warning: Stanza model for {lang_code} may already be present. ({e})")
-
         stanza_pipelines[language] = stanza.Pipeline(
             lang_code,
             processors="tokenize,mwt,pos,lemma",
             tokenize_no_ssplit=True
         )
-
     return stanza_pipelines[language]
+
+
+def get_cltk_lemmatizer(language: str):
+    global cltk_lemmatizers
+    if language.lower() == "latin" and cltk_lemmatizers["latin"] is None:
+        cltk_lemmatizers["latin"] = LatinBackoffLemmatizer()
+    if language.lower() == "greek" and cltk_lemmatizers["greek"] is None:
+        cltk_lemmatizers["greek"] = GreekBackoffLemmatizer()
+    return cltk_lemmatizers.get(language.lower())
 
 
 @router.get("/")
@@ -82,14 +168,14 @@ async def lemmatizing_handler(
         if text and the_text != b'':
             return "Please choose just one input method."
 
-        if text:  # input from form
+        if text:
             csv_output = lemmatize(text, location, regex_go_brrr, language, lemma_lex, format, poetry)
-            outputfile.write('\ufeff'.encode('utf-8'))
+            outputfile.write('﻿'.encode('utf-8'))
             outputfile.write(csv_output.encode('utf-8'))
-        elif the_text:  # input from file
+        elif the_text:
             text = the_text.decode("utf-8")
             csv_output = lemmatize(text, location, regex_go_brrr, language, lemma_lex, format, poetry)
-            outputfile.write('\ufeff'.encode('utf-8'))
+            outputfile.write('﻿'.encode('utf-8'))
             outputfile.write(csv_output.encode('utf-8'))
         else:
             return "Please enter or upload text."
@@ -103,6 +189,46 @@ def strip_accents(s: str):
 
 def depunctuate(text: str):
     return regex.sub(f"[{string.punctuation}]", "", text)
+
+
+def hybrid_lemmatize_word(word_clean: str, language: str, stanza_pipeline) -> str:
+    """
+    CLTK + Stanza hybrid for Latin and Greek.
+    1. Invariables
+    2. CLTK as primary
+    3. Stanza as fallback
+    """
+    lang = language.lower()
+
+    # Check invariables
+    if lang == "latin" and word_clean in LATIN_INVARIABLES:
+        return LATIN_INVARIABLES[word_clean]
+    if lang == "greek" and word_clean in GREEK_INVARIABLES:
+        return GREEK_INVARIABLES[word_clean]
+
+    # Try CLTK
+    cltk = get_cltk_lemmatizer(language)
+    if cltk:
+        results = cltk.lemmatize([word_clean])
+        if results:
+            cltk_lemma = clean_cltk_lemma(results[0][1])
+            if lang == "latin":
+                if cltk_lemma and not cltk_lemma_is_inflected(cltk_lemma, word_clean):
+                    return cltk_lemma
+            else:
+                # For Greek, always trust CLTK if it returned something
+                if cltk_lemma:
+                    return cltk_lemma
+
+    # Fall back to Stanza
+    if stanza_pipeline:
+        doc = stanza_pipeline(word_clean)
+        for sent in doc.sentences:
+            for w in sent.words:
+                if w.lemma:
+                    return w.lemma
+
+    return "NONE"
 
 
 def lemmatize(text, location, regex_go_brrr, language, lemma_lex, format, poetry):
@@ -121,7 +247,7 @@ def lemmatize(text, location, regex_go_brrr, language, lemma_lex, format, poetry
     words = text.split()
 
     stanza_pipeline = None
-    if format.upper() == "STANZA":
+    if format.upper() in ("STANZA", "HYBRID"):
         stanza_pipeline = get_pipeline(language.lower())
 
     for word in words:
@@ -139,27 +265,35 @@ def lemmatize(text, location, regex_go_brrr, language, lemma_lex, format, poetry
             section += 1
             word = word.replace(marker, "")
 
-        word_clean = depunctuate(strip_accents(word)).lower()
+        # For Greek, preserve accents — don't strip them
+        if language.lower() == "greek":
+            word_clean = depunctuate(word)
+        else:
+            word_clean = depunctuate(strip_accents(word)).lower()
+
         if not word_clean:
             continue
 
-        if word_clean in lemma_lex and format.upper() != "STANZA":
-            title = lemma_lex[word_clean]
-            title = conversion.get(title, f"morpheus: {title}")
-        else:
-            title = "morpheus: NONE"
-        if format.upper() == "STANZA" and stanza_pipeline is not None:
+        if format.upper() == "HYBRID":
+            lemma = hybrid_lemmatize_word(word_clean, language, stanza_pipeline)
+            title = f"hybrid: {lemma}" if lemma != "NONE" else "hybrid: NONE"
+
+        elif format.upper() == "STANZA" and stanza_pipeline is not None:
             doc = stanza_pipeline(word_clean)
             lemma = None
             for sent in doc.sentences:
                 for w in sent.words:
-                    if w.text.lower() == word_clean:
+                    if w.lemma:
                         lemma = w.lemma
                         break
-            if lemma:
-                title = f"stanza: {lemma}"
+            title = f"stanza: {lemma}" if lemma else "stanza: NONE"
+
+        else:
+            if word_clean in lemma_lex:
+                title = lemma_lex[word_clean]
+                title = conversion.get(title, f"morpheus: {title}")
             else:
-                title = "stanza: NONE"
+                title = "morpheus: NONE"
 
         output_lines.append(f"{title},{location},{section},{running_count},{word_original}")
         running_count += 1

--- a/FastBridgeApp/routers/ToolsApp/lemmatize.py
+++ b/FastBridgeApp/routers/ToolsApp/lemmatize.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request, File, Form, UploadFile
 from fastapi.templating import Jinja2Templates
 from starlette.responses import FileResponse
 import importlib
+import os
 import tempfile
 from pathlib import Path
 import re as regex
@@ -21,7 +22,8 @@ logging.getLogger("stanza.pipeline").setLevel(logging.ERROR)
 
 from cltk.lemmatize.lat import LatinBackoffLemmatizer
 from cltk.lemmatize.grc import GreekBackoffLemmatizer
-
+from cltk.utils import CLTK_DATA_DIR
+from cltk.data.fetch import FetchCorpus
 router = APIRouter()
 router_path = Path.cwd()
 templates = Jinja2Templates(directory="templates")
@@ -35,6 +37,24 @@ cltk_lemmatizers = {
     "latin": None,
     "greek": None,
 }
+# CLTK backoff-lemmatizer corpora, fetched into ~/cltk_data on demand
+CLTK_CORPORA = {
+    "latin": ("lat", "lat_models_cltk"),
+    "greek": ("grc", "grc_models_cltk"),
+}
+
+
+def _ensure_cltk_corpus(language: str):
+    """Download the CLTK backoff corpus for `language` if it isn't already
+    present. Mirrors the runtime stanza.download() pattern in get_pipeline().
+    No-op when the corpus was baked into the image at build time."""
+    lang_code, corpus_name = CLTK_CORPORA[language.lower()]
+    model_dir = os.path.join(CLTK_DATA_DIR, lang_code, "model", corpus_name)
+    if not os.path.isdir(model_dir):
+        try:
+            FetchCorpus(lang_code).import_corpus(corpus_name)
+        except Exception as e:
+            print(f"Warning: could not fetch CLTK corpus {corpus_name}: {e}")
 
 # Invariable Latin words — hardcoded ground truth
 LATIN_INVARIABLES = {
@@ -130,8 +150,10 @@ def get_pipeline(language: str):
 def get_cltk_lemmatizer(language: str):
     global cltk_lemmatizers
     if language.lower() == "latin" and cltk_lemmatizers["latin"] is None:
+        _ensure_cltk_corpus("latin")
         cltk_lemmatizers["latin"] = LatinBackoffLemmatizer()
     if language.lower() == "greek" and cltk_lemmatizers["greek"] is None:
+        _ensure_cltk_corpus("greek")
         cltk_lemmatizers["greek"] = GreekBackoffLemmatizer()
     return cltk_lemmatizers.get(language.lower())
 

--- a/FastBridgeApp/routers/ToolsApp/lemmatize.py
+++ b/FastBridgeApp/routers/ToolsApp/lemmatize.py
@@ -269,7 +269,7 @@ def lemmatize(text, location, regex_go_brrr, language, lemma_lex, format, poetry
     words = text.split()
 
     stanza_pipeline = None
-    if format.upper() in ("STANZA", "HYBRID"):
+    if "STANZA" in format.upper() or "HYBRID" in format.upper():
         stanza_pipeline = get_pipeline(language.lower())
 
     for word in words:
@@ -296,7 +296,7 @@ def lemmatize(text, location, regex_go_brrr, language, lemma_lex, format, poetry
         if not word_clean:
             continue
 
-        if format.upper() == "HYBRID":
+        if "HYBRID" in format.upper():
             lemma = hybrid_lemmatize_word(word_clean, language, stanza_pipeline)
             title = f"hybrid: {lemma}" if lemma != "NONE" else "hybrid: NONE"
 

--- a/FastBridgeApp/templates/lemmatize.html
+++ b/FastBridgeApp/templates/lemmatize.html
@@ -38,10 +38,11 @@ With Bridge/Lemmatizer you can create a lemmatization spreadsheet for any Latin 
   </div>
 
   <div class="mb-3">
-  <label for="format" class="form-label">4. In which format would you like your lemmata? (Stanza can handle longer texts than Bridge. Must use it for greek. Also it's more accurate for latin than Bridge)</label>
+  <label for="format" class="form-label">4. In which format would you like your lemmata? </label>
   <select name="format" id="format" class="form-select">
     <option>Bridge</option>
     <option>Stanza</option>
+    <option>Hybrid</option>
   </select>
 </div>
 

--- a/FastBridgeApp/templates/lemmatize.html
+++ b/FastBridgeApp/templates/lemmatize.html
@@ -42,7 +42,7 @@ With Bridge/Lemmatizer you can create a lemmatization spreadsheet for any Latin 
   <select name="format" id="format" class="form-select">
     <option>Bridge</option>
     <option>Stanza</option>
-    <option>Hybrid</option>
+    <option>Hybrid (CLTK)</option>
   </select>
 </div>
 

--- a/FastBridgeApp/templates/lemmatize.html
+++ b/FastBridgeApp/templates/lemmatize.html
@@ -42,8 +42,9 @@ With Bridge/Lemmatizer you can create a lemmatization spreadsheet for any Latin 
   <p style="color: #ccc; font-size: 0.9em;">
     <strong>Bridge</strong> uses a pre-built morpheus lexicon dictionary to quickly look up lemmas. Fast and reliable for common words, but limited in coverage for rarer forms.<br><br>
     <strong>Stanza</strong> uses a neural network trained on classical Latin and Greek texts. Better at rare words and unusual forms, but slower and occasionally unreliable on common function words.<br><br>
-    <strong>Hybrid (CLTK)</strong> combines both approaches for the best accuracy. Common function words (prepositions, conjunctions, pronouns) are resolved from a hardcoded table, CLTK handles the bulk of classical vocabulary, and Stanza steps in as a fallback for anything CLTK cannot resolve. Recommended for most texts.
-  </p>
+    <strong>Hybrid (CLTK)</strong> combines both approaches for the best accuracy. Common function words (prepositions, conjunctions, pronouns) are resolved from a hardcoded table, CLTK (Classical Language Toolkit, a rule-based NLP library for ancient languages) handles the bulk of classical vocabulary, and Stanza steps in as a fallback for anything CLTK cannot resolve. Recommended for most texts.
+
+
   <select name="format" id="format" class="form-select">
     <option>Bridge</option>
     <option>Stanza</option>

--- a/FastBridgeApp/templates/lemmatize.html
+++ b/FastBridgeApp/templates/lemmatize.html
@@ -37,8 +37,13 @@ With Bridge/Lemmatizer you can create a lemmatization spreadsheet for any Latin 
     </select>
   </div>
 
-  <div class="mb-3">
+<div class="mb-3">
   <label for="format" class="form-label">4. In which format would you like your lemmata? </label>
+  <p style="color: #ccc; font-size: 0.9em;">
+    <strong>Bridge</strong> uses a pre-built morpheus lexicon dictionary to quickly look up lemmas. Fast and reliable for common words, but limited in coverage for rarer forms.<br><br>
+    <strong>Stanza</strong> uses a neural network trained on classical Latin and Greek texts. Better at rare words and unusual forms, but slower and occasionally unreliable on common function words.<br><br>
+    <strong>Hybrid (CLTK)</strong> combines both approaches for the best accuracy. Common function words (prepositions, conjunctions, pronouns) are resolved from a hardcoded table, CLTK handles the bulk of classical vocabulary, and Stanza steps in as a fallback for anything CLTK cannot resolve. Recommended for most texts.
+  </p>
   <select name="format" id="format" class="form-select">
     <option>Bridge</option>
     <option>Stanza</option>


### PR DESCRIPTION
This branch adds a new Hybrid (CLTK) lemmatization format to the Bridge Lemmatizer tool, alongside the existing Bridge and Stanza options.
The hybrid method works in three steps: first, common Latin and Greek function words (prepositions, conjunctions, pronouns, articles) are resolved from a hardcoded invariables table since both tools frequently get these wrong. Second, CLTK's backoff lemmatizer handles the bulk of classical vocabulary using its lexicon and morphological rules. Third, Stanza's neural network steps in as a fallback for any word CLTK cannot resolve.
Greek support was also added, with accents preserved throughout processing since CLTK's Greek lexicon requires fully-accented polytonic forms. Accuracy testing on classical Latin and Greek prose showed ~94% for Latin and ~97% for Greek, averaging ~95.5% — compared to ~83-88% for Stanza alone.
The CLTK corpora are downloaded automatically on first use, mirroring the existing Stanza download behavior. Format descriptions were also added to the lemmatize page so users understand the difference between each option.