### PR TITLE
Bug fix: prevent extended loading screen on vocab page

### DIFF
--- a/FastBridgeApp/templates/userspace.html
+++ b/FastBridgeApp/templates/userspace.html
@@ -10,7 +10,7 @@
         <p style="color:#ccc; margin-bottom:24px;"><em>This is your user dashboard. Here you can manage your account and saved lists.</em></p>
 
         <div class="dashboard-tabs" role="tablist" style="display:flex; justify-content:center; margin-bottom:24px; border-bottom: 2px solid #444; color:#fff;">
-          <a href="/userspace/vocab" class="user-tab active" role="tab" aria-selected="true" aria-controls="vocabulary" style="color:#fff; padding:12px 24px; text-decoration:none; border-bottom: 3px solid #228383;">Vocabulary</a>
+          <a href="/userspace/vocab" data-no-spinner class="user-tab active" role="tab" aria-selected="true" aria-controls="vocabulary" style="color:#fff; padding:12px 24px; text-decoration:none; border-bottom: 3px solid #228383;">Vocabulary</a>
           <a href="#" class="user-tab" role="tab" aria-selected="false" aria-controls="create" style="color:#ccc; padding:12px 24px; text-decoration:none;">Create List</a>
           <a href="#" class="user-tab" role="tab" aria-selected="false" aria-controls="saved-searches" id="saved-searches-tab" style="color:#ccc; padding:12px 24px; text-decoration:none;">Saved Searches</a>
         </div>


### PR DESCRIPTION
There used to be an issue with a stale loading buffer or spinner when navigating from any other tab in the user space to vocabulary. The database itself was very fast, so the spinner was just there for the full length because it did not know what to do. I was able to safely remove it