### PR TITLE
Update requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ End-to-end tests (Playwright + accessibility) live in `FastBridgeApp/tests/e2e/`
 
 ### Notes
 
-Use python 3.11
+Use python 3.12
 
 ## Requirements.txt notes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,7 @@ oauth2client==4.1.3
 oauthlib==3.1.0
 orjson==3.10.18
 packaging==20.4
-pandas>=1.5,<2.0
+pandas>=1.5,<3.0
 passlib==1.7.2
 pillow==11.3.0
 plotly==6.2.0


### PR DESCRIPTION
Due to the production Python version being changed, the old version of pandas does not work and needs to be updated to at least version 2. After testing the new pandas version in my dev environment, this is a safe update.